### PR TITLE
Prevent invalid Moritani assassination scenarios

### DIFF
--- a/src/main/java/controller/commands/CommandManager.java
+++ b/src/main/java/controller/commands/CommandManager.java
@@ -888,7 +888,7 @@ public class CommandManager extends ListenerAdapter {
             homeworld.setOccupierName(occupierName);
     }
 
-    private void assassinateTraitor(DiscordGame discordGame, Game game) throws ChannelNotFoundException {
+    private void assassinateTraitor(DiscordGame discordGame, Game game) throws ChannelNotFoundException, InvalidGameStateException {
         game.getMoritaniFaction().assassinateTraitor();
         discordGame.pushGame();
     }

--- a/src/main/java/model/factions/MoritaniFaction.java
+++ b/src/main/java/model/factions/MoritaniFaction.java
@@ -397,9 +397,16 @@ public class MoritaniFaction extends Faction {
         return newAssassinationTargetNeeded;
     }
 
-    public void assassinateTraitor() {
-        String assassinated = traitorHand.getFirst().getName();
-        assassinationTargets.add(traitorHand.getFirst().getEmojiAndNameString());
+    public void assassinateTraitor() throws InvalidGameStateException {
+        if (traitorHand.isEmpty())
+            throw new InvalidGameStateException("Moritani has already assassinated this turn.");
+        TraitorCard traitor = traitorHand.getFirst();
+        String assassinated = traitor.getName();
+        if (game.getLeaderTanks().stream().anyMatch(l -> l.getName().equals(assassinated)))
+            throw new InvalidGameStateException(assassinated + " is in the tanks and cannot be assassinated.");
+        else if (assassinationTargets.stream().anyMatch(t -> t.contains(traitor.getFactionEmoji())))
+            throw new InvalidGameStateException("Moritani cannot assassinate the same faction twice.");
+        assassinationTargets.add(traitor.getEmojiAndNameString());
         traitorHand.clear();
         setUpdated(UpdateType.MISC_FRONT_OF_SHIELD);
         for (Faction faction : game.getFactions()) {

--- a/src/test/java/model/factions/MoritaniFactionTest.java
+++ b/src/test/java/model/factions/MoritaniFactionTest.java
@@ -540,7 +540,7 @@ public class MoritaniFactionTest extends FactionTestTemplate {
         }
 
         @Test
-        void testassassinationSuccessful() {
+        void testassassinationSuccessful() throws InvalidGameStateException {
             faction.assassinateTraitor();
             assertTrue(faction.getAssassinationTargets().contains(Emojis.HARKONNEN + " Feyd Rautha"));
             assertTrue(faction.getTraitorHand().isEmpty());
@@ -549,6 +549,25 @@ public class MoritaniFactionTest extends FactionTestTemplate {
             assertTrue(faction.isNewAssassinationTargetNeeded());
             assertFalse(harkonnen.getLeaders().contains(feydRautha));
             assertTrue(game.getLeaderTanks().contains(feydRautha));
+        }
+
+        @Test
+        void testCannotAssassinateLeaderInTanks() {
+            game.killLeader(harkonnen, "Feyd Rautha");
+            assertThrows(InvalidGameStateException.class, () -> faction.assassinateTraitor());
+        }
+
+        @Test
+        void testCannotAssassinateSameFactionTwice() {
+            faction.getAssassinationTargets().add(Emojis.HARKONNEN + " Beast Rabban");
+            game.killLeader(harkonnen, "Feyd Rautha");
+            assertThrows(InvalidGameStateException.class, () -> faction.assassinateTraitor());
+        }
+
+        @Test
+        void testCannotAssassinateTwiceOnSameTurn() throws InvalidGameStateException {
+            faction.assassinateTraitor();
+            assertThrows(InvalidGameStateException.class, () -> faction.assassinateTraitor());
         }
     }
 
@@ -780,7 +799,7 @@ public class MoritaniFactionTest extends FactionTestTemplate {
         }
 
         @Test
-        void testAssassinationNewLeaderNeeded() throws IOException {
+        void testAssassinationNewLeaderNeeded() throws IOException, InvalidGameStateException {
             HarkonnenFaction harkonnen;
             harkonnen = new HarkonnenFaction("p", "u");
             harkonnen.setLedger(new TestTopic());


### PR DESCRIPTION
- Moritani has already assassinated and has no Traitor (just better error message)
- Traitor is in the tanks (now blocked - then unblocked in subsequent PR since it is allowed but no spice collected)
- Target faction has already had an assassination (now blocked)